### PR TITLE
Allow glide 3 and update testsuite

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,8 +15,8 @@ jobs:
                 glide-version: [^2, ^3]
                 dependencies: [lowest, stable]
                 exclude:
-                  - php: 8.1
-                    symfony: ^7
+                  - php-version: 8.1
+                    symfony-version: ^7
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,6 +13,7 @@ jobs:
                 php: [8.1, 8.2, 8.3, 8.4]
                 symfony: [^5, ^6, ^7]
                 glide: [^2, ^3]
+                dependency-version: [prefer-lowest, prefer-stable]
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,20 +10,23 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [8.1, 8.2, 8.3, 8.4]
-                symfony: [^5, ^6, ^7]
-                glide: [^2, ^3]
-                dependency-version: [prefer-lowest, prefer-stable]
+                php-version: [8.1, 8.2, 8.3, 8.4]
+                symfony-version: [^5, ^6, ^7]
+                glide-version: [^2, ^3]
+                dependencies: [lowest, stable]
+                exclude:
+                  - php: 8.1
+                    symfony: ^7
         steps:
             - name: Checkout
               uses: actions/checkout@v4
             - name: Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                php-version: ${{ matrix.php }}
+                php-version: ${{ matrix.php-version }}
             - name: Install dependencies
               run: |
-                composer require "symfony/http-foundation:${{ matrix.symfony }}" "league/glide:${{ matrix.glide }}" --no-interaction --no-update
-                composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --with-all-dependencies
+                composer require "symfony/http-foundation:${{ matrix.symfony-version }}" "league/glide:${{ matrix.glide-version }}" --no-interaction --no-update
+                composer update --prefer-${{ matrix.dependencies }} --prefer-dist --no-interaction --no-suggest --with-all-dependencies
             - name: PHPUnit
               run: php vendor/bin/phpunit

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,15 +10,19 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+                php: [8.1, 8.2, 8.3, 8.4]
+                symfony: [^5, ^6, ^7]
+                glide: [^2, ^3]
         steps:
             - name: Checkout
               uses: actions/checkout@v4
             - name: Install PHP
               uses: shivammathur/setup-php@v2
               with:
-                php-version: ${{ matrix.php-versions }}
+                php-version: ${{ matrix.php }}
             - name: Install dependencies
-              run: composer install --no-interaction --no-ansi
+              run: |
+                composer require "symfony/http-foundation:${{ matrix.symfony }}" "league/glide:${{ matrix.glide }}" --no-interaction --no-update
+                composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest --with-all-dependencies
             - name: PHPUnit
               run: php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "league/glide": "^2.0",
+        "league/glide": "^2.0|^3.0",
         "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
-        "phpunit/phpunit": "^8.5|^9.4"
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,9 @@
         }
     ],
     "require": {
+        "php": "^8.1",
         "league/glide": "^2.0|^3.0",
-        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|^6.0|^7.0|^8.0"
+        "symfony/http-foundation": "^5|^6|^7|^8"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,16 +5,9 @@
             <directory suffix="Test.php">tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+        </include>
+    </source>
 </phpunit>

--- a/src/Responses/SymfonyResponseFactory.php
+++ b/src/Responses/SymfonyResponseFactory.php
@@ -18,7 +18,7 @@ class SymfonyResponseFactory implements ResponseFactoryInterface
      * Create SymfonyResponseFactory instance.
      * @param Request|null $request Request object to check "is not modified".
      */
-    public function __construct(Request $request = null)
+    public function __construct(?Request $request = null)
     {
         $this->request = $request;
     }

--- a/tests/Responses/SymfonyResponseFactoryTest.php
+++ b/tests/Responses/SymfonyResponseFactoryTest.php
@@ -5,6 +5,7 @@ namespace Responses;
 use League\Glide\Responses\SymfonyResponseFactory;
 use Mockery;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 class SymfonyResponseFactoryTest extends TestCase
 {
@@ -37,5 +38,25 @@ class SymfonyResponseFactoryTest extends TestCase
         self::assertEquals('0', $response->headers->get('Content-Length'));
         self::assertStringContainsString(gmdate('D, d M Y H:i', strtotime('+1 years')), $response->headers->get('Expires'));
         self::assertEquals('max-age=31536000, public', $response->headers->get('Cache-Control'));
+    }
+
+    public function testCreateWithRequest(): void
+    {
+        $cache = Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('mimeType')->andReturn('image/jpeg')->once();
+            $mock->shouldReceive('fileSize')->andReturn(0)->once();
+            $mock->shouldReceive('readStream');
+            $mock->shouldReceive('lastModified')->andReturn(strtotime('2025-01-01'));
+        });
+
+        $factory = new SymfonyResponseFactory(new Request());
+        $response = $factory->create($cache, '');
+
+        self::assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response);
+        self::assertEquals('image/jpeg', $response->headers->get('Content-Type'));
+        self::assertEquals('0', $response->headers->get('Content-Length'));
+        self::assertStringContainsString(gmdate('D, d M Y H:i', strtotime('+1 years')), $response->headers->get('Expires'));
+        self::assertEquals('max-age=31536000, public', $response->headers->get('Cache-Control'));
+        self::assertEquals('Wed, 01 Jan 2025 00:00:00 GMT', $response->headers->get('Last-Modified'));
     }
 }


### PR DESCRIPTION
This is based on https://github.com/thephpleague/glide-symfony/pull/19

- Allows Glide 3 install
- Updates PHP to 8.1 and Symfony to 5 minimum (supported versions for Glide 3 and maintained Symfony packages)
- Update test matrix to test all supported versions.
- Add test for passing the Request object