### PR TITLE
Add Symfony 8 support and PHP 8.3/8.4 to CI

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,10 +10,10 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+                php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
             - name: Install PHP
               uses: shivammathur/setup-php@v2
               with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "league/glide": "^2.0",
-        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|^6.0|^7.0"
+        "symfony/http-foundation": "^2.3|^3.0|^4.0|^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",


### PR DESCRIPTION
- Add symfony/http-foundation ^8.0 constraint
- Add PHP 8.3 and 8.4 to CI test matrix
- Update actions/checkout to v4